### PR TITLE
Add commutativity optimization support for generation

### DIFF
--- a/dialects/arith-test.mlir
+++ b/dialects/arith-test.mlir
@@ -1,0 +1,22 @@
+module {
+
+// Not implemented because we don't use index: arith.index_cast, arith.index_castui
+// Not implemented because we don't have constraints for integer attribute: arith.constant
+
+  irdl.dialect @arith {
+
+
+    irdl.operation @andi attributes {commutativity}{
+    //irdl.operation @andi {
+      %integer = irdl.base "!builtin.integer"
+      irdl.operands(%integer, %integer)
+      irdl.results(%integer)
+    }
+
+    //irdl.operation @xori {
+    //  %integer = irdl.base "!builtin.integer"
+    //  irdl.operands(%integer, %integer)
+    //  irdl.results(%integer)
+    //}
+  }
+}

--- a/dialects/arith-test.mlir
+++ b/dialects/arith-test.mlir
@@ -6,17 +6,17 @@ module {
   irdl.dialect @arith {
 
 
-    irdl.operation @andi attributes {commutativity}{
-    //irdl.operation @andi {
-      %integer = irdl.base "!builtin.integer"
-      irdl.operands(%integer, %integer)
-      irdl.results(%integer)
+    //irdl.operation @addi attributes {commutativity}{
+    irdl.operation @addi attributes {commutativity} {
+          %integer = irdl.base "!builtin.integer"
+          irdl.operands(%integer, %integer)
+          irdl.results(%integer)
     }
 
-    //irdl.operation @xori {
-    //  %integer = irdl.base "!builtin.integer"
-    //  irdl.operands(%integer, %integer)
-    //  irdl.results(%integer)
-    //}
+    irdl.operation @muli attributes {commutativity} {
+          %integer = irdl.base "!builtin.integer"
+          irdl.operands(%integer, %integer)
+          irdl.results(%integer)
+        }
   }
 }

--- a/include/GeneratorInfo.h
+++ b/include/GeneratorInfo.h
@@ -14,6 +14,7 @@
 #define MLIR_FUZZ_GENERATOR_INFO_H
 
 #include "guide.h"
+#include <functional>
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/IRDL/IR/IRDL.h"
@@ -110,6 +111,15 @@ struct GeneratorInfo {
   /// Returns as well the indices of the results that can have this result type.
   std::vector<std::pair<mlir::irdl::OperationOp, std::vector<int>>>
   getOperationsWithResultType(mlir::Type resultType);
+
+  /// Return the list of operations that can have a particular result type as
+  /// result with a filter.
+  /// We only consider operations making filter true.
+  /// Returns as well the indices of the results that can have this result type.
+  std::vector<std::pair<mlir::irdl::OperationOp, std::vector<int>>>
+  getOperationsWithResultType(
+      mlir::Type resultType,
+      std::function<bool(mlir::irdl::OperationOp)> filter);
 
   /// Add an operation with a given result type.
   /// Return the result that has has the requested type.

--- a/include/GeneratorInfo.h
+++ b/include/GeneratorInfo.h
@@ -121,6 +121,13 @@ struct GeneratorInfo {
       mlir::Type resultType,
       std::function<bool(mlir::irdl::OperationOp)> filter);
 
+  /// Create an operation with a given operation op
+  /// Return the operation created
+  /// This function is used inside of addRootedOperation
+  mlir::Operation *createOperation(mlir::irdl::OperationOp op,
+                                   mlir::Type resultType, int resultIdx,
+                                   int fuel);
+
   /// Add an operation with a given result type.
   /// Return the result that has has the requested type.
   /// This function will also create a number proportional to `fuel` operations.

--- a/include/GeneratorInfo.h
+++ b/include/GeneratorInfo.h
@@ -79,15 +79,15 @@ struct GeneratorInfo {
     dominatingValues[value.getType()].push_back(value);
   }
 
-  /// Get a value in the program.
-  std::optional<mlir::Value> getValue(mlir::Type type) {
+  /// Get a value in the program and its index in the dominating array.
+  std::pair<std::optional<mlir::Value>, int> getValue(mlir::Type type) {
     auto &domValues = dominatingValues[type];
 
     if (domValues.size() == 0) {
-      return {};
+      return {{}, -1};
     }
     auto choice = chooser->choose(domValues.size());
-    return domValues[choice];
+    return {domValues[choice], choice};
   }
 
   mlir::Value addFunctionArgument(mlir::Type type) {
@@ -129,10 +129,11 @@ struct GeneratorInfo {
                                    int fuel);
 
   /// Add an operation with a given result type.
-  /// Return the result that has has the requested type.
-  /// This function will also create a number proportional to `fuel` operations.
-  std::optional<mlir::Value> addRootedOperation(mlir::Type resultType,
-                                                int fuel);
+  /// Return the result that has has the requested type and the index of that
+  /// value if it has zero cost. This function will also create a number
+  /// proportional to `fuel` operations.
+  std::pair<std::optional<mlir::Value>, int>
+  addRootedOperation(mlir::Type resultType, int fuel);
 };
 
 /// Create a random program, given the decisions taken from chooser.

--- a/lib/GeneratorInfo.cpp
+++ b/lib/GeneratorInfo.cpp
@@ -11,6 +11,7 @@
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/IR/BuiltinOps.h"
+#include <unordered_set>
 
 using namespace mlir;
 using namespace mlir::irdl;
@@ -139,13 +140,169 @@ static std::optional<Value> getZeroCostValue(GeneratorInfo &info, Type type) {
   return info.createValueOutOfThinAir(info, type);
 }
 
+static bool isNonZeroCost(mlir::ArrayRef<mlir::irdl::OperationOp> availableOps,
+                          mlir::Operation *op) {
+  static std::unordered_set<std::string> opNames;
+  if (opNames.empty()) {
+    assert(!availableOps.empty());
+    auto frontOp = availableOps[0];
+    auto dialectName = frontOp.getParentOp().getName();
+    for (auto op : availableOps) {
+      std::string opName = dialectName.str() + "." + op.getNameAttr().str();
+      opNames.insert(opName);
+    }
+  }
+
+  return opNames.find(op->getName().getStringRef().str()) != opNames.end();
+}
+
+mlir::Operation *GeneratorInfo::createOperation(mlir::irdl::OperationOp op,
+                                                mlir::Type resultType,
+                                                int resultIdx, int fuel) {
+  const static std::string COMMUTATIVITY = "commutativity";
+  auto ctx = builder.getContext();
+
+  // Create a new verifier that will keep track of the values we have already
+  // assigned.
+  auto [constraints, valueToIdx] = getOperationVerifier(op);
+  auto verifier = ConstraintVerifier(constraints);
+
+  // Add to the constraint verifier our set result.
+  auto succeeded =
+      verifier.verify({}, TypeAttr::get(resultType),
+                      valueToIdx[getResultsConstraints(op)[resultIdx]]);
+  assert(succeeded.succeeded());
+
+  std::vector<Value> operands;
+  if (op->hasAttr(COMMUTATIVITY)) {
+    auto operandsConstraints = getOperandsConstraints(op);
+    int LHSfuel = chooser->choose(fuel + 1), RHSfuel = fuel - LHSfuel;
+    auto satisfyingTypes = getSatisfyingTypes(
+        *ctx, valueToIdx[operandsConstraints[0]], verifier, availableTypes);
+    if (satisfyingTypes.empty())
+      return nullptr;
+    auto LHStype = satisfyingTypes[chooser->choose(satisfyingTypes.size())];
+
+    // We only update this filter if we successfully created operations on LHS
+    std::function<bool(mlir::irdl::OperationOp)> filter =
+        [](mlir::irdl::OperationOp op) { return true; };
+
+    // LHS can be generated freely
+    auto LHSvalue = addRootedOperation(LHStype, LHSfuel);
+    if (!LHSvalue.has_value()) {
+      return nullptr;
+    }
+    if (mlir::Operation *LHSoperation = LHSvalue->getDefiningOp();
+        LHSoperation != nullptr && isNonZeroCost(availableOps, LHSoperation)) {
+      std::string LHSopName = LHSoperation->getName().getStringRef().str();
+      LHSopName =
+          std::string(std::find(LHSopName.begin(), LHSopName.end(), '.') + 1,
+                      LHSopName.end());
+      filter = [&LHSopName](mlir::irdl::OperationOp op) {
+        return op.getSymName() >= LHSopName;
+      };
+    }
+    operands.push_back(*LHSvalue);
+
+    // Now we generate RHS
+    satisfyingTypes = getSatisfyingTypes(
+        *ctx, valueToIdx[operandsConstraints[1]], verifier, availableTypes);
+    if (satisfyingTypes.empty())
+      return nullptr;
+    auto RHStype = satisfyingTypes[chooser->choose(satisfyingTypes.size())];
+    std::optional<Value> RHSvalue;
+
+    auto RHSoperations = getOperationsWithResultType(resultType, filter);
+    if (RHSoperations.empty() || RHSfuel == 0)
+      RHSvalue = getZeroCostValue(*this, RHStype);
+    else {
+      auto [RHSop, possibleResults] =
+          RHSoperations[chooser->choose(RHSoperations.size())];
+      size_t RHSresultIdx =
+          possibleResults[chooser->choose(possibleResults.size())];
+
+      mlir::Operation *RHSoperation =
+          createOperation(RHSop, RHStype, RHSresultIdx, RHSfuel - 1);
+      if (RHSoperation == nullptr) {
+        return nullptr;
+      }
+      for (auto result : RHSoperation->getResults()) {
+        addDominatingValue(result);
+      }
+
+      RHSvalue = RHSoperation->getResult(resultIdx);
+    }
+    operands.push_back(*RHSvalue);
+  } else {
+    for (auto operand : getOperandsConstraints(op)) {
+      auto satisfyingTypes = getSatisfyingTypes(*ctx, valueToIdx[operand],
+                                                verifier, availableTypes);
+      if (satisfyingTypes.empty())
+        return nullptr;
+
+      auto type = satisfyingTypes[chooser->choose(satisfyingTypes.size())];
+      auto succeeded =
+          verifier.verify({}, TypeAttr::get(type), valueToIdx[operand]);
+      assert(succeeded.succeeded());
+
+      int operandFuel = chooser->choose(fuel + 1);
+      fuel -= operandFuel;
+
+      auto operandValue = addRootedOperation(type, operandFuel);
+      if (!operandValue.has_value())
+        return nullptr;
+      operands.push_back(*operandValue);
+    }
+  }
+
+  std::vector<Type> resultTypes;
+  for (auto [idx, result] : llvm::enumerate(getResultsConstraints(op))) {
+    if (resultIdx == idx) {
+      resultTypes.push_back(resultType);
+      continue;
+    }
+
+    auto satisfyingTypes =
+        getSatisfyingTypes(*ctx, valueToIdx[result], verifier, availableTypes);
+    if (satisfyingTypes.size() == 0)
+      return nullptr;
+
+    auto type = satisfyingTypes[chooser->choose(satisfyingTypes.size())];
+    auto succeeded =
+        verifier.verify({}, TypeAttr::get(type), valueToIdx[result]);
+    assert(succeeded.succeeded());
+    resultTypes.push_back(type);
+  }
+
+  std::vector<NamedAttribute> attributes;
+  for (auto [name, constraint] : getAttributesConstraints(op)) {
+    auto satisfyingAttrs = getSatisfyingAttrs(*ctx, valueToIdx[constraint],
+                                              verifier, availableAttributes);
+    if (satisfyingAttrs.size() == 0)
+      return nullptr;
+
+    auto attr = satisfyingAttrs[chooser->choose(satisfyingAttrs.size())];
+    auto succeeded = verifier.verify({}, attr, valueToIdx[constraint]);
+    assert(succeeded.succeeded());
+    attributes.emplace_back(StringAttr::get(ctx, name), attr);
+  }
+
+  StringRef dialectName = op.getParentOp().getName();
+  StringRef opSuffix = op.getNameAttr().getValue();
+  StringAttr opName = StringAttr::get(ctx, dialectName + "." + opSuffix);
+
+  // Create the operation.
+  auto *operation = builder.create(UnknownLoc::get(ctx), opName, operands,
+                                   resultTypes, attributes);
+  return operation;
+}
+
 /// Add an operation with a given result type.
 /// Return the result that has has the requested type.
 /// This function will also create a number of operations less than `fuel`
 /// operations.
 std::optional<Value> GeneratorInfo::addRootedOperation(Type resultType,
                                                        int fuel) {
-  auto ctx = builder.getContext();
 
   // When we don't have fuel anymore, we either use a dominated value,
   // or we create a value out of thin air, which may include adding
@@ -163,77 +320,10 @@ std::optional<Value> GeneratorInfo::addRootedOperation(Type resultType,
   auto [op, possibleResults] = operations[chooser->choose(operations.size())];
   size_t resultIdx = possibleResults[chooser->choose(possibleResults.size())];
 
-  // Create a new verifier that will keep track of the values we have already
-  // assigned.
-  auto [constraints, valueToIdx] = getOperationVerifier(op);
-  auto verifier = ConstraintVerifier(constraints);
-
-  // Add to the constraint verifier our set result.
-  auto succeeded =
-      verifier.verify({}, TypeAttr::get(resultType),
-                      valueToIdx[getResultsConstraints(op)[resultIdx]]);
-  assert(succeeded.succeeded());
-
-  std::vector<Value> operands;
-  for (auto operand : getOperandsConstraints(op)) {
-    auto satisfyingTypes =
-        getSatisfyingTypes(*ctx, valueToIdx[operand], verifier, availableTypes);
-    if (satisfyingTypes.empty())
-      return {};
-
-    auto type = satisfyingTypes[chooser->choose(satisfyingTypes.size())];
-    auto succeeded =
-        verifier.verify({}, TypeAttr::get(type), valueToIdx[operand]);
-    assert(succeeded.succeeded());
-
-    int operandFuel = chooser->choose(fuel + 1);
-    fuel -= operandFuel;
-
-    auto operandValue = addRootedOperation(type, operandFuel);
-    if (!operandValue.has_value())
-      return {};
-    operands.push_back(*operandValue);
+  mlir::Operation *operation = createOperation(op, resultType, resultIdx, fuel);
+  if (operation == nullptr) {
+    return {};
   }
-
-  std::vector<Type> resultTypes;
-  for (auto [idx, result] : llvm::enumerate(getResultsConstraints(op))) {
-    if (resultIdx == idx) {
-      resultTypes.push_back(resultType);
-      continue;
-    }
-
-    auto satisfyingTypes =
-        getSatisfyingTypes(*ctx, valueToIdx[result], verifier, availableTypes);
-    if (satisfyingTypes.size() == 0)
-      return {};
-
-    auto type = satisfyingTypes[chooser->choose(satisfyingTypes.size())];
-    auto succeeded =
-        verifier.verify({}, TypeAttr::get(type), valueToIdx[result]);
-    assert(succeeded.succeeded());
-    resultTypes.push_back(type);
-  }
-
-  std::vector<NamedAttribute> attributes;
-  for (auto [name, constraint] : getAttributesConstraints(op)) {
-    auto satisfyingAttrs = getSatisfyingAttrs(*ctx, valueToIdx[constraint],
-                                              verifier, availableAttributes);
-    if (satisfyingAttrs.size() == 0)
-      return {};
-
-    auto attr = satisfyingAttrs[chooser->choose(satisfyingAttrs.size())];
-    auto succeeded = verifier.verify({}, attr, valueToIdx[constraint]);
-    assert(succeeded.succeeded());
-    attributes.emplace_back(StringAttr::get(ctx, name), attr);
-  }
-
-  StringRef dialectName = op.getParentOp().getName();
-  StringRef opSuffix = op.getNameAttr().getValue();
-  StringAttr opName = StringAttr::get(ctx, dialectName + "." + opSuffix);
-
-  // Create the operation.
-  auto *operation = builder.create(UnknownLoc::get(ctx), opName, operands,
-                                   resultTypes, attributes);
   for (auto result : operation->getResults()) {
     addDominatingValue(result);
   }

--- a/tools/mlir-enumerate/mlir-enumerate.cpp
+++ b/tools/mlir-enumerate/mlir-enumerate.cpp
@@ -149,7 +149,7 @@ int main(int argc, char **argv) {
     auto &domValues = info.dominatingValues[type];
 
     if (domValues.size()) {
-      auto value = info.getValue(type);
+      auto [value, valueIndex] = info.getValue(type);
       assert(value && "Error in generator logic");
       return *value;
     }

--- a/tools/superoptimizer/superoptimizer.cpp
+++ b/tools/superoptimizer/superoptimizer.cpp
@@ -74,7 +74,7 @@ OwningOpRef<ModuleOp> createProgramFromInput(
       info.addDominatingValue(result);
 
   auto type = func.getFunctionType().getResult(0);
-  auto root = info.addRootedOperation(type, numOps);
+  auto [root, rootIsZeroCost] = info.addRootedOperation(type, numOps);
   if (!root.has_value())
     return nullptr;
   builder.create<func::ReturnOp>(unknownLoc, *root);
@@ -155,7 +155,7 @@ int main(int argc, char **argv) {
         op->getName().getStringRef() != "hw.constant")
       numInputOps += 1;
   });
-  maxNumOps = std::min((int)maxNumOps, numInputOps - 1);
+  maxNumOps = std::min((int)maxNumOps, numInputOps);
 
   // Try to parse the dialects.
   auto optDialects = parseMLIRFile(ctx, inputIRDLFilename);
@@ -169,7 +169,6 @@ int main(int argc, char **argv) {
   std::vector<OperationOp> availableOps = {};
   dialects->walk(
       [&availableOps](OperationOp op) { availableOps.push_back(op); });
-
   size_t programCounter = 0;
   size_t correctProgramCounter = 0;
 


### PR DESCRIPTION
This MR intends to add `commutativity` optimization in search stage. 
    To support `commutativity`, I defined a priority that operations are larger than dominated values or values created from air (Let's call this kind of values as `zero-cost value` since we don't need any resources to build them).
    
As a result, for a commutative operation `(op a b)`, `b` must have a less or equal priority than `a`. In summary, it has following three cases:

1. `a` and `b` both are operations    
       In this scenario, I limit the operation name `b` must be less than `a`'s to skip redundance.
2. `a` is an operation and `b` is a zero-cost value
      No constraints here
3. `a` and `b` both are zero-cost values
      There is an array called `dominatingValues` for storing all dominated value with a certain type. Value `b` must has a less or equal index than `a` in the array.

It includes following changes:
+ An `arith-test` specification including two operations with `commutativity` flag
+ `tools/mlir-enumerate/mlir-enumerate.cpp` && `tools/superoptimizer/superoptimizer.cpp`: Update function calls
+ `GenerationInfo.h` && `GenerationInfo.cpp`
    1. Split `addRootOpereation`. If we have no more fuel, it calls `getZeroCostValue`; otherwise, it randomly selects an operation from all possible operations and calls `createOperation` to create that operation. It returns a value with specified type and a index indicating the location in `domanatingValues` for zero-cost values; -1 if it is not a zero-cost value
    2. Add `createOperation`. Given an operation, it create that operation in place.  If the operation doesn't have a `commutativity` flag, it calls `addRootOperation` for all parameters; otherwise it generates both parameters as the algorithm described above
    3. Extend `getOperationsWithResultType` to support case 1 in the algorithm. It finds a subset of all possible operations given a result type and a filter
    4. Add `getZeroCostValueWithIndex` to support case 3 in the algorithm

@regehr 